### PR TITLE
The GitHub Actions workflow was failing to deploy to GitHub Pages bec…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,49 +8,31 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  contents: write
 
 jobs:
-  # Build job
-  build:
+  build-and-deploy:
+    concurrency: ci-${{ github.ref }} # Recommended concurrency configuration
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"
+
       - name: Install dependencies
         run: npm install
+
       - name: Build
         run: npm run build
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          # Upload dist folder
-          path: './dist'
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist


### PR DESCRIPTION
…ause of a mismatch between the deployment mechanism and the repository's settings.

The workflow was configured to use `actions/deploy-pages@v4`, which deploys using a build artifact. However, the GitHub Pages settings were configured to deploy from the `gh-pages` branch.

This commit updates the `.github/workflows/deploy.yml` file to use the `peaceiris/actions-gh-pages` action. This action builds the project and pushes the `dist` directory to the `gh-pages` branch, which aligns with the existing GitHub Pages configuration and will trigger a successful deployment.